### PR TITLE
Avoid memset "optimization" on core1

### DIFF
--- a/RA/init.cpp
+++ b/RA/init.cpp
@@ -2785,7 +2785,13 @@ static void Init_Expansion_Files(void)
 		do {
 			ptr = strdup(state.name);
 			new MFCD(ptr, &FastKey);
-			MFCD::Cache(ptr);
+			#if PICO_BUILD
+			// Scores.mix is too large to cache.
+			if (stricmp(ptr, "scores.mix") != 0)
+			#endif
+			{
+				MFCD::Cache(ptr);
+			}
 		} while (Find_Next_File(state));
 	}
 	if (Find_First_File("SS*.MIX", state)) {


### PR DESCRIPTION
And also ensure scores isn't accidentally cached.

It's stable for me with this tweak, video even stays up when caching files to flash!